### PR TITLE
SYNR-1243

### DIFF
--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -38,7 +38,6 @@ defineEnum <- function(assignEnumCallback, name, keys, values) {
 
   newArgs <- setNames(rep(list(quote(expr =)), length(argNames)), argNames)
 
-  ## If there are no defaults
   if (length(defaults) > 0) {
     ## Otherwise fill in arguments with defaults at the end, and add empty symbols
     ## to any remaining arguments

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -25,15 +25,55 @@ defineEnum <- function(assignEnumCallback, name, keys, values) {
   assignEnumCallback(name, keys, values)
 }
 
+# Create formal args that can be assigned to a function
+# based on the inspected Python signature.
+# @param pyParams the function info args as from getFunctionInfo
+.createFormalArgs <- function(pyParams) {
+  argNames <- pyParams$args
+  defaults <- pyParams$defaults
+
+  if (length(argNames) > 0 && argNames[1] == 'self') {
+    argNames <- argNames[-1]
+  }
+
+  newArgs <- setNames(rep(list(quote(expr =)), length(argNames)), argNames)
+
+  ## If there are no defaults
+  if (length(defaults) > 0) {
+    ## Otherwise fill in arguments with defaults at the end, and add empty symbols
+    ## to any remaining arguments
+    nArgs <- length(argNames)
+    nDefs <- length(defaults)
+
+    ## Position of the last default-less argument
+    lastEmpty <- nArgs - nDefs
+
+    ## Add the defaults to the end
+    newArgs[(lastEmpty + 1):nArgs] <- defaults
+  }
+
+  if (!is.null(pyParams$varargs) || !is.null(pyParams$keywords)) {
+    # if the Python signature uses *args or **kwargs we add
+    # dots to the R signature to match
+    newArgs <- append(newArgs, alist(... =))
+  }
+
+  return(newArgs)
+}
+
 # Define an R wrapper for a object constructor in Python
 #
 # @param module the python module
 # @param setGenericCallback the callback to setGeneric defined in the target R package
 # @param name the class name
-defineConstructor <- function(module, setGenericCallback, name) {
+# @param pyParams the function info args as from getFunctionInfo
+defineConstructor <- function(module, setGenericCallback, name, pyParams) {
   force(name)
   force(module)
-  assign(sprintf(".%s", name), function(...) {
+  force(pyParams)
+
+  rWrapperName <- sprintf(".%s", name)
+  assign(rWrapperName, function(...) {
     pyModule <- pyGet(module)
     argsAndKwArgs <- determineArgsAndKwArgs(...)
     functionAndArgs <- append(list(pyModule, name), argsAndKwArgs$args)
@@ -46,12 +86,22 @@ defineConstructor <- function(module, setGenericCallback, name) {
       )
     )
   })
-  setGenericCallback(
-    name,
-    function(...) {
-      do.call(sprintf(".%s", name), args = list(...))
-    }
-  )
+
+  rFn <- function(...) {
+    # formals will be assigned below, re-create the dots
+    # so we can pass them through to the py call
+    call <- sys.call()
+    call[[1]] <- as.name('list')
+    dots <- eval.parent(call)
+    do.call(rWrapperName, args = dots)
+  }
+
+  newArgs <- .createFormalArgs(pyParams)
+  if (length(newArgs) > 0) {
+    formals(rFn) <- newArgs
+  }
+
+  setGenericCallback(name, rFn)
 }
 
 # Helper function to generate R wrappers for classes in a python module
@@ -61,7 +111,7 @@ defineConstructor <- function(module, setGenericCallback, name) {
 # @param classInfo the classes to generate R wrappers for
 autoGenerateClasses <- function(module, setGenericCallback, classInfo) {
   for (c in classInfo) {
-    defineConstructor(module, setGenericCallback, c$name)
+    defineConstructor(module, setGenericCallback, c$name, c$args)
   }
 }
 
@@ -70,17 +120,20 @@ autoGenerateClasses <- function(module, setGenericCallback, classInfo) {
 # @param rName the R function name
 # @param pyName the Python function name
 # @param functionContainerName the function container name in Python
+# @param pyParams the function info args as from getFunctionInfo
 # @param setGenericCallback the callback to setGeneric defined in the target R package
 # @param transformReturnObject optional function to change returned values in R
 defineFunction <- function(rName,
                            pyName,
                            functionContainerName,
+                           pyParams,
                            setGenericCallback,
                            transformReturnObject = NULL) {
   pyImport("gateway")
   force(rName)
   force(pyName)
   force(functionContainerName)
+  force(pyParams)
   rWrapperName <- sprintf(".%s", rName)
 
   assign(rWrapperName, function(...) {
@@ -107,9 +160,22 @@ defineFunction <- function(rName,
       returnedObject
     }
   })
-  setGenericCallback(rName, function(...) {
-    do.call(rWrapperName, args = list(...))
-  })
+
+  rFn <- function(...) {
+    # formals will be assigned below, re-create the dots
+    # so we can pass them through to the py call
+    call <- sys.call()
+    call[[1]] <- as.name('list')
+    dots <- eval.parent(call)
+    do.call(rWrapperName, args = dots)
+  }
+
+  newArgs <- .createFormalArgs(pyParams)
+  if (length(newArgs) > 0) {
+    formals(rFn) <- newArgs
+  }
+
+  setGenericCallback(rName, rFn)
 }
 
 # Helper function to generate R wrappers for functions in a python module
@@ -125,6 +191,7 @@ autoGenerateFunctions <- function(setGenericCallback,
       f$rName,
       f$pyName,
       f$functionContainerName,
+      f$args,
       setGenericCallback,
       transformReturnObject
     )

--- a/tests/testthat/testPyPkgWrapper.py
+++ b/tests/testthat/testPyPkgWrapper.py
@@ -1,5 +1,6 @@
 # test module
 from enum import Enum
+import functools
 
 class DIGIT(Enum):
   ZERO = 0
@@ -81,3 +82,11 @@ def incObj(x):
   :return: the value of x.inc().
   """
   return(x.inc())
+
+# a more complex signature. our wrapper should be able to
+# follow through a decorator, handle keyword only args,
+# and not get tripped up by type annotations.
+@functools.lru_cache()
+def myFunComplexArgs(a: int, b=2, *, c=3, **kwargs):
+  return a + b + c + kwargs.get('d', 0)
+

--- a/tests/testthat/test_generateRWrappers.R
+++ b/tests/testthat/test_generateRWrappers.R
@@ -53,7 +53,7 @@ test_that("defineFunction with same name", {
 test_that("defineFunction with different name", {
   pyImport("testPyPkgWrapper")
   pyImport("gateway")
-  pyParams = list(args=c('input'), varargs=NULL, keywords=NULL, defaults=c())
+  pyParams = list(args=c('n'), varargs=NULL, keywords=NULL, defaults=c())
   PythonEmbedInR:::defineFunction(rName = "myRFunc",
                                   pyName = "myFun",
                                   pyParams = pyParams,
@@ -63,10 +63,28 @@ test_that("defineFunction with different name", {
   expect_equal(myRFunc(4), 4)
 })
 
+test_that("defineFunction complex signature", {
+  pyImport("testPyPkgWrapper")
+  pyImport("gateway")
+  pyParams = list(args=c('a', 'b', 'c'), varargs=NULL, keywords='**kwargs', defaults=c(2, 3))
+  PythonEmbedInR:::defineFunction(rName = "myRFuncComplexArgs",
+                                  pyName = "myFunComplexArgs",
+                                  pyParams = pyParams,
+                                  functionContainerName = "testPyPkgWrapper",
+                                  setGenericCallback = callback)
+  expect_equal(myRFuncComplexArgs(1, d=4), 10)
+  expect_equal(myRFuncComplexArgs(1, b=3, c=5), 9)
+
+  # also confirm formals are assigned to the wrapper
+  expected_formals <- alist(a=, b=2, c=3, ...=)
+  expect_equal(names(expected_formals), names(formals(myRFuncComplexArgs)))
+  expect_equal(unlist(expected_formals, use.names=FALSE), unlist(formals(myRFuncComplexArgs), use.names=FALSE))
+})
+
 test_that("GeneratorWrapper", {
   pyImport("testPyPkgWrapper")
   pyImport("gateway")
-  pyParams = list(args=c('input'), varargs=NULL, keywords=NULL, defaults=c())
+  pyParams = list(args=c(), varargs=NULL, keywords=NULL, defaults=c())
   PythonEmbedInR:::defineFunction(rName = "myGenerator",
                                   pyName = "myGenerator",
                                   pyParams = pyParams,
@@ -85,7 +103,7 @@ test_that("defineFunction with transform return object", {
   inc <- function(x) {
     x + 1
   }
-  pyParams = list(args=c('input'), varargs=NULL, keywords=NULL, defaults=c())
+  pyParams = list(args=c('n'), varargs=NULL, keywords=NULL, defaults=c())
   PythonEmbedInR:::defineFunction(rName = "myFun",
                                   pyName = "myFun",
                                   pyParams = pyParams,

--- a/tests/testthat/test_generateRWrappers.R
+++ b/tests/testthat/test_generateRWrappers.R
@@ -27,9 +27,11 @@ test_that("defineEnum", {
 test_that("defineConstructor", {
   pyImport("testPyPkgWrapper")
   pyImport("gateway")
+  pyParams = list(args=c('self'))
   PythonEmbedInR:::defineConstructor(module = "testPyPkgWrapper",
                                      setGenericCallback = callback,
-                                     name = "MyObj")
+                                     name = "MyObj",
+                                     pyParams = pyParams)
   obj <- MyObj()
   expect_equal(obj$print(), 0)
   expect_equal(obj$inc(), 1)
@@ -38,8 +40,10 @@ test_that("defineConstructor", {
 test_that("defineFunction with same name", {
   pyImport("testPyPkgWrapper")
   pyImport("gateway")
+  pyParams = list(args=c('input'), varargs=NULL, keywords=NULL, defaults=c())
   PythonEmbedInR:::defineFunction(rName = "myFun",
                                   pyName = "myFun",
+                                  pyParams = pyParams,
                                   functionContainerName = "testPyPkgWrapper",
                                   setGenericCallback = callback)
   expect_equal(myFun(-4), 4)
@@ -49,8 +53,10 @@ test_that("defineFunction with same name", {
 test_that("defineFunction with different name", {
   pyImport("testPyPkgWrapper")
   pyImport("gateway")
+  pyParams = list(args=c('input'), varargs=NULL, keywords=NULL, defaults=c())
   PythonEmbedInR:::defineFunction(rName = "myRFunc",
                                   pyName = "myFun",
+                                  pyParams = pyParams,
                                   functionContainerName = "testPyPkgWrapper",
                                   setGenericCallback = callback)
   expect_equal(myRFunc(-4), 4)
@@ -60,8 +66,10 @@ test_that("defineFunction with different name", {
 test_that("GeneratorWrapper", {
   pyImport("testPyPkgWrapper")
   pyImport("gateway")
+  pyParams = list(args=c('input'), varargs=NULL, keywords=NULL, defaults=c())
   PythonEmbedInR:::defineFunction(rName = "myGenerator",
                                   pyName = "myGenerator",
+                                  pyParams = pyParams,
                                   functionContainerName = "testPyPkgWrapper",
                                   setGenericCallback = callback)
   generator <- myGenerator()
@@ -77,8 +85,10 @@ test_that("defineFunction with transform return object", {
   inc <- function(x) {
     x + 1
   }
+  pyParams = list(args=c('input'), varargs=NULL, keywords=NULL, defaults=c())
   PythonEmbedInR:::defineFunction(rName = "myFun",
                                   pyName = "myFun",
+                                  pyParams = pyParams,
                                   functionContainerName = "testPyPkgWrapper",
                                   setGenericCallback = callback,
                                   transformReturnObject = inc)


### PR DESCRIPTION
Does 2 things:

1. Replaces the use of the deprecated inspect.getargpsec when inspecting Python signatures to generate R wrappers with inspect.signature. getargpsec doesn't support some modern Python constructs such as keyword only arguments, type annotations, and decorators, all three of which we have added to the Python client on wrapped public signatures since the last time we built synapser. These changes are needed to be able to build synapser.

2. Uses the signature data to assign formal arguments to the R wrapper functions, as requested in https://sagebionetworks.jira.com/browse/SYNR-1243