### PR TITLE
SYNR-1475 upgrade pip for better wheel compatibility

### DIFF
--- a/configure
+++ b/configure
@@ -93,6 +93,10 @@ cd ..
 rm -R ${PYTHON_ARCHIVE_NAME}
 cd ..
 
+# ensure that the embedded python interpreter has newer version of pip so that
+# downstream package installations will have a better chance of installing precompiled wheels
+${EMBED_PYTHON_DIR}/bin/python${EMBED_PYTHON_VERSION} -m pip install pip==21.0.1
+
 # these exact paths vary by python version so use wildcard expansions to find the actual path
 MYPYTHONCONFIG=$(ls ${EMBED_PYTHON_DIR}/bin/python${EMBED_PYTHON_VERSION}*-config)
 MYPYTHONLIBDIR=$(ls -d ${EMBED_PYTHON_DIR}/lib/python${EMBED_PYTHON_VERSION}/*config-${EMBED_PYTHON_VERSION}*)

--- a/configure.win
+++ b/configure.win
@@ -48,9 +48,10 @@ install_python() {
       sed -i 's/#import site/import site/g' $PTH_FILE
   fi
 
+  # install pip, match the version we install in the main configure script
   PIP_INSTALL_SCRIPT=get-pip.py
   curl -o $PIP_INSTALL_SCRIPT https://bootstrap.pypa.io/get-pip.py
-  ./python.exe $PIP_INSTALL_SCRIPT pip==18.1
+  ./python.exe $PIP_INSTALL_SCRIPT pip==21.0.1
   cd ../..
 }
 

--- a/inst/python/pip_install.py
+++ b/inst/python/pip_install.py
@@ -1,0 +1,79 @@
+"""
+Utility functions for installing/removing pip packages programatically
+""" 
+
+import glob
+import inspect
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _find_python_interpreter():
+    # helper heuristic to find the bundled python interpreter binary associated
+    # with PythonEmbedInR. we need it in order to be able to invoke pip via
+    # a subprocess. it's not in the same place because of how we build
+    # PythonEmbedInR differently between the OSes.
+
+    possible_interpreter_filenames = [
+        'python',
+        'python{}'.format(sys.version_info.major),
+        'python{}.{}'.format(sys.version_info.major, sys.version_info.minor),
+    ]
+    possible_interpreter_filenames.extend(['{}.exe'.format(f) for f in possible_interpreter_filenames])
+    possible_interpreter_filenames.extend([os.path.join('bin', f).format(f) for f in possible_interpreter_filenames])
+
+    last_path = None
+    path = inspect.getfile(os)
+    while(path and path != last_path):
+        for f in possible_interpreter_filenames:
+            file_path = os.path.join(path, f)
+            if os.path.isfile(file_path) and os.access(file_path, os.X_OK):
+                return file_path
+
+        last_path = path
+        path = os.path.dirname(path)
+
+    # if we didn't find anything we'll hope there is any 'python3' interpreter on the path.
+    # we're just going to use it to install some modules into a specific directory
+    # so it doesn't actually even have to be the one bundled with PythonEmbedInR
+    return 'python{}'.format(sys.version_info.major)
+
+
+PYTHON_INTERPRETER = _find_python_interpreter()
+
+
+def install(package, package_dir):
+    """
+    Programatically install a package via pip
+    :param package: the name of the python package to install via pip
+    :param package_dir: the directory to install the package into
+    """
+
+    # the recommended way to call pip at runtime is by invoking a subprocess,
+    # but that's complicated by the fact that we don't know where the python
+    # interpreter is. usually you can do sys.executable but in the embedded
+    # context sys.executable is R, not python. So we do a heuristic to
+    # find the interpreter. this seems to work better here than calling main
+    # on pip directly which doesn't work for some of these packages (separately
+    # from the other issues above...)
+    rc = subprocess.call([PYTHON_INTERPRETER, "-m", "pip", "install", package, "--upgrade", "--quiet", "--target", package_dir])
+    if rc != 0:
+        raise Exception("pip returned {} when installing {}".format(rc, package))
+
+
+def remove(prefix, package_dir):
+    """
+    Remove a package installed via this script.
+    :param prefix: a package or package prefix
+    :param package_dir: the directory the package was installed into
+    """
+
+    # pip doesn't offer a way to uninstall from a specific target directory.
+    # instead we delete all traces matching the given prefix
+    to_remove = glob.iglob(os.path.join(package_dir, prefix+"*"))
+    for path in to_remove:
+      if os.path.isdir(path):
+        shutil.rmtree(path)
+

--- a/tests/testthat/install_pandas.py
+++ b/tests/testthat/install_pandas.py
@@ -5,65 +5,63 @@ import pkg_resources
 import glob
 import shutil
 
+import inspect
+import subprocess
+
+
 # pin the version that we use in this test
 # e.g. 1.0.3 has issues installing from a wheel on Windows
 # not related to PythonEmbedInR
 # https://stackoverflow.com/q/60767017
 PANDAS_VERSION="1.0.1"
 
-# pip main is not a public interface and is not programatically accessible
-# in a stable way across python versions. the typical approach is to
-# call pip in a subprocess using sys.executable, but running inside
-# PythonEmbedInR sys.executable may not be what we want.
-try:
-    from pip import main as pipmain
-except ImportError:
-    from pip._internal import main as pipmain
 
 def localSitePackageFolder(root):
     if os.name=='nt':
         # Windows
-        return root+os.sep+"Lib"+os.sep+"site-packages"
-    else:
-        # Mac, Linux
-        return root+os.sep+"lib"+os.sep+"python3.6"+os.sep+"site-packages"
-    
+        return os.path.join(root, 'Lib', 'site-packages')
+    # Mac, Linux
+    return os.path.join(root, 'lib', "python{}.{}".format(sys.version_info.major, sys.version_info.minor), 'site-packages')
+
 def addLocalSitePackageToPythonPath(root):
     # PYTHONPATH sets the search path for importing python modules
     sitePackages = localSitePackageFolder(root)
-    os.environ['PYTHONPATH'] = sitePackages
+
+    os.environ['PYTHONPATH'] += sitePackages
     sys.path.append(sitePackages)
+
+    # include PythonEmbedInR/inst/python so we can use the pip_install function
+    inst_module_dir = os.path.join(root, 'python')
+    os.environ['PYTHONPATH'] += inst_module_dir
+    sys.path.append(inst_module_dir)
+
     # modules with .egg extensions (such as future and synapseClient) need to be explicitly added to the sys.path
     for eggpath in glob.glob(sitePackages+os.sep+'*.egg'):
         os.environ['PYTHONPATH'] += os.pathsep+eggpath
         sys.path.append(eggpath)
-    
-def main(command, path):
-    path = pkg_resources.normalize_path(path)
-    moduleInstallationPrefix=path+os.sep+"inst"
 
+
+def main(command, path):
+    """
+    Install pandas or remove for testing.
+    :param command: "install" or "uninstall"
+    :param path: the path prefix of the directory to install pandas into
+    """
+
+    path = pkg_resources.normalize_path(path)
+    moduleInstallationPrefix = os.path.join(path, 'inst')
     localSitePackages=localSitePackageFolder(moduleInstallationPrefix)
-    
+
     addLocalSitePackageToPythonPath(moduleInstallationPrefix)
+    from pip_install import install as pip_install, remove as pip_remove
 
     if not os.path.exists(localSitePackages):
-      os.makedirs(localSitePackages)
+        os.makedirs(localSitePackages)
 
     if command == 'install':
-      call_pip('pandas', localSitePackages, PANDAS_VERSION)
+        pip_install('pandas=={}'.format(PANDAS_VERSION), localSitePackages)
     elif command == 'uninstall':
-      remove_dirs('pandas', localSitePackages)
+        pip_remove('pandas', localSitePackages)
     else:
-      raise Exception("command not supported: "+command)
+        raise Exception("command not supported: "+command)
 
-def call_pip(packageName, target, packageVersion=None):
-    package = packageName if not packageVersion else "{}=={}".format(packageName, packageVersion)
-    rc = pipmain(["install", package, '--no-cache-dir', '--disable-pip-version-check', '--upgrade', '--quiet', '--target', target])
-    if rc!=0:
-      raise Exception('pip.main returned '+str(rc))
-
-def remove_dirs(prefix, baseDir):
-    to_remove = glob.iglob(os.path.join(baseDir, prefix+"*"))
-    for path in to_remove:
-      if os.path.isdir(path):
-        shutil.rmtree(path)


### PR DESCRIPTION
Part of a two pronged fix to prevent recent changes to the python cryptography package from affecting installations of synapser. https://github.com/Sage-Bionetworks/synapser/issues/293

The latest version of synapsePythonClient conditionally pins a version of cryptography for now that is not affected by these changes so the next version of synapser will inherit this change. https://github.com/Sage-Bionetworks/synapsePythonClient/pull/813

However this issue also revealed that due to an older version of pip shipped with synapser via PythonEmbedInR some precompiled wheels (including those for cryptography) were not being used, instead forcing compilation from source code which allowed the cryptography Rust dependency to manifest as an issue.

This change ensures that PythonEmbedInR includes a newer version of pip. This requires some changes to how we use pip since newer versions of pip do not support pip invoked programmatically through an imported module (technically this was never supported but it has started to fail on newer versions of pip, especially on windows). This changes the pip usage to be invoked via subprocess which is the recommended approach. https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
