### PR TITLE
SYNR-1474 expose underscore functions

### DIFF
--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -133,7 +133,6 @@ defineFunction <- function(rName,
   force(pyName)
   force(functionContainerName)
   force(pyParams)
-
   rWrapperName <- sprintf(".%s", rName)
 
   assign(rWrapperName, function(...) {

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -133,6 +133,7 @@ defineFunction <- function(rName,
   force(pyName)
   force(functionContainerName)
   force(pyParams)
+
   rWrapperName <- sprintf(".%s", rName)
 
   assign(rWrapperName, function(...) {
@@ -197,14 +198,34 @@ autoGenerateFunctions <- function(setGenericCallback,
   }
 }
 
+# Helper function to camel case the given input
+#
+# @param x the input string
+snakeToCamel <- function(x) {
+  title <- function(x) {
+    paste0(
+      toupper(substring(x, 1, 1)),
+      substring(x, 2, nchar(x))
+    )
+  }
+
+  sapply(
+    strsplit(x, "_"),
+    function(x) {
+      paste(title(x), collapse="")
+    }
+  )
+}
+
+
 # Helper function to add prefix to a name
 #
 # @param name the name to add prefix to
 # @param prefix the prefix to add
 addPrefix <- function(name, prefix) {
-  paste(prefix,
-    toupper(substring(name, 1, 1)),
-    substring(name, 2, nchar(name)),
+  paste(
+    prefix,
+    snakeToCamel(name),
     sep = ""
   )
 }

--- a/R/PythonPkgWrapperUtils.R
+++ b/R/PythonPkgWrapperUtils.R
@@ -197,21 +197,26 @@ autoGenerateFunctions <- function(setGenericCallback,
   }
 }
 
+
+# Helper function to capitalize the first letter of the input
+#
+# @param x the input string
+capitalizeFirstLetter <- function(x) {
+  paste0(
+    toupper(substring(x, 1, 1)),
+    substring(x, 2, nchar(x))
+  )
+}
+
+
 # Helper function to camel case the given input
 #
 # @param x the input string
 snakeToCamel <- function(x) {
-  title <- function(x) {
-    paste0(
-      toupper(substring(x, 1, 1)),
-      substring(x, 2, nchar(x))
-    )
-  }
-
   sapply(
     strsplit(x, "_"),
     function(x) {
-      paste(title(x), collapse="")
+      paste(capitalizeFirstLetter(x), collapse="")
     }
   )
 }


### PR DESCRIPTION
Return prefixed underscored functions read from the underlying as Python camel cased.

For example, instead if the Python function is `Synapse#is_certified` then return `synIsCertified` instead of `synIs_certified`.

This is related to https://sagebionetworks.jira.com/browse/SYNR-1474 where the NAMESPACE was suppressing exported functions with underscore anyway.